### PR TITLE
37 100bpm 기준으로 비트맵 grid 6칸임의정도로 나누기

### DIFF
--- a/ProjectNT/Assets/02.Audio/Music/Sample.wav.meta
+++ b/ProjectNT/Assets/02.Audio/Music/Sample.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: fca09404af0a0fb439e93ee8a22bba4f
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/AudioVisualizable.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/AudioVisualizable.cs
@@ -68,8 +68,6 @@ public class AudioVisualizable : MonoBehaviour
             print($"heightPerSecond의 최대값 : {maxSample}");
         }
 
-        print($"텍스쳐의 높이 : {textureHeight}");
-
         //거의 256이면 깨끗한 해상도가 나옴
         int textureWidth = 256;
         //픽셀 초기화

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/BeatMapPlane.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/BeatMapPlane.cs
@@ -14,8 +14,5 @@ public class BeatMapPlane : MonoBehaviour
     public void HandleBeatMapPosZ(float sliderValue)
     {
         transform.position = Vector3.back * (_audioSourceManager.AudioSource.clip.length * sliderValue);
-        print($"슬라이더 값 : {sliderValue}");
-        print($"포지션 값 : {transform.position.z}");
-        print($"오디오 길이 값: {_audioSourceManager.AudioSource.clip.length}");
     }
 }

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/AudioSourceManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/AudioSourceManager.cs
@@ -25,7 +25,7 @@ public class AudioSourceManager : MonoBehaviour
     {
         if (cameraController._isRotating == false)
         {
-            if (Input.GetKey(KeyCode.Space))
+            if (Input.GetKeyDown(KeyCode.Space))
             {
                 print($"스페이스바 눌림"); 
                 _isPlaying = !_isPlaying;

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
@@ -8,20 +8,26 @@ public class GridManager : MonoBehaviour
     [SerializeField] private GameObject targetObject;
     [Header("가로 길이(클수록 가로로 길어짐)")]
     [SerializeField] private float widthScale = 1f;
-    [Header("새로 길이(클수록 새로로 길어짐)")]
+    [Header("세로 길이(클수록 세로로 길어짐)")]
     [SerializeField] private float heightScale = 1f;
     [Header("Texture해상도")]
-    [SerializeField] private float texturePerSecond;
-    [SerializeField] private int row;    //열(가로줄)
-    [SerializeField] private int column = 4; //행(새로줄)
+    [SerializeField] private float texturePerSecond = 2048f; // 텍스처 해상도 증가
+    [Header("Grid 설정")]
+    [SerializeField] private float bpm = 120;
+    [SerializeField] private int beatsPerBar = 4; // 마디당 박자의 수
+    [SerializeField] private int subdivision = 4; // 박자
+    [SerializeField] private int nodesPerBeat = 1; //비트당 노드 수
+    [SerializeField] private int row;    // 열(가로줄)
+    [SerializeField] private int column = 4; // 행(세로줄)
     [SerializeField] private Color gridColor = Color.black;
+    [SerializeField] private Color subGridColor = new Color(0.5f, 0.5f, 0.5f, 0.5f); // 서브그리드 색상
     [SerializeField] private Color backgroundColor = Color.white;
     [SerializeField] private float lineThickness = 2f;
 
     private AudioSourceManager _audioSourceManager;
     private Texture2D _gridTexture;
     private Material _targetMaterial;
-
+    private const float BASE_BPM = 120f; // 기준이 되는 BPM
 
     private void Awake()
     {
@@ -55,25 +61,26 @@ public class GridManager : MonoBehaviour
             renderer.material = _targetMaterial;
 
             float duration = _audioSourceManager.AudioDuration;
-            float hight = duration * heightScale;
-
-            targetObject.transform.localScale = new Vector3(widthScale / 10f, 1, hight / 10f);
+            float height = duration * heightScale;
+            targetObject.transform.localScale = new Vector3(widthScale / 10f, 1, height / 10f);
         }
     }
 
-    //텍스쳐 크기 결정
     private void CreateGridTexture()
     {
         float duration = _audioSourceManager.AudioDuration;
-        int height = (int)(duration * texturePerSecond);
+
+        int height = Mathf.CeilToInt(duration * texturePerSecond);
+
         if (height > AudioVisualizable.MAX_TEXTUREWIDTH)
         {
-            int maxSample = AudioVisualizable.MAX_TEXTUREWIDTH / (int)duration;
-            height = (int)(duration * maxSample);
-            print($"heightPerSecond의 최대값 : {maxSample}");
+            height = AudioVisualizable.MAX_TEXTUREWIDTH;
+            Debug.LogWarning("텍스처 크기가 최대 크기를 초과");
         }
-        int width = 256;
+
+        int width = 2048; // 가로 해상도도 증가
         _gridTexture = new Texture2D(width, height, TextureFormat.RGBA32, false);
+        _gridTexture.filterMode = FilterMode.Bilinear; // 선명한 텍스처를 위해 필터모드 설정
     }
 
     private void UpdateGrid()
@@ -86,7 +93,7 @@ public class GridManager : MonoBehaviour
 
     private void GenerateGrid()
     {
-        //배경 설정
+        // 배경 설정
         for (int y = 0; y < _gridTexture.height; y++)
         {
             for (int x = 0; x < _gridTexture.width; x++)
@@ -95,29 +102,163 @@ public class GridManager : MonoBehaviour
             }
         }
 
-        int cellWidth = _gridTexture.height / row;
-        int cellHeight = _gridTexture.width / column;
+        float songDuration = _audioSourceManager.AudioDuration;
+        //초당 픽셀
+        float pixelsPerSecond = _gridTexture.height / songDuration;
+        //초당 bpm
+        float secondsPerBeat = 60 / bpm;
+        //1비트 당 픽셀
+        float pixelsPerBeat = pixelsPerSecond * secondsPerBeat;
 
-        for (int y = 0; y < _gridTexture.height; y++)
+        float columnWidth = _gridTexture.width / (float)column;
+        for (int x = 0; x < column; x++)
         {
-            for (int x = 0; x < _gridTexture.width; x++)
-            {
-                if (x == cellWidth || y == cellHeight)
-                {
-                    _gridTexture.SetPixel(x, y, gridColor);
-                }
-                //int cellWidth = _gridTexture.height / row;
-                //int cellHeight = _gridTexture.width / column;
+            int xPos = Mathf.RoundToInt(x * columnWidth);
+            DrawVerticalLine(xPos, gridColor);
+        }
 
-                //bool isGridLine = (x % cellWidth < lineThickness || y % cellHeight < lineThickness);
-
-                //if (isGridLine)
-                //{
-                //    _gridTexture.SetPixel(x, y, gridColor);
-                //}
-            }
+        for (float y = 0; y < _gridTexture.height; y += pixelsPerBeat)
+        {
+            DrawHorizontalLine(Mathf.FloorToInt(y), gridColor);
         }
 
         _gridTexture.Apply();
+        //int subdivisionHeight = Mathf.RoundToInt((_gridTexture.height / (_gridTexture.height / subdivision)) * bpmScale);
+        //int beatHeight = subdivisionHeight * subdivision;
+        //int barHeight = beatHeight * beatsPerBar;
+
+        //노드 서브선
+        //float nodeSubdivisionHeight = beatHeight / (float)nodesPerBeat;
+        //// 세로선 그리기 (열)
+        //float columnWidth = _gridTexture.width / (float)column;
+
+        //for (int x = 0; x < column; x++)
+        //{
+        //    int xPos = Mathf.RoundToInt(x * columnWidth);
+        //    DrawVerticalLine(xPos, gridColor);
+        //}
+
+        //// 가로선 그리기 (박자선, 노드 서브디비전)
+        //for (int y = 0; y < _gridTexture.height; y++)
+        //{
+        //    Color lineColor;
+        //    if (y % barHeight == 0) // 마디선
+        //    {
+        //        lineColor = gridColor;
+        //        DrawHorizontalLine(y, lineColor);
+        //    }
+        //    else if (y % beatHeight == 0) // 박자선
+        //    {
+        //        lineColor = gridColor;
+        //        DrawHorizontalLine(y, lineColor);
+        //    }
+        //    else if (y % nodeSubdivisionHeight < 1) // 노드 서브디비전 선
+        //    {
+        //        lineColor = subGridColor;
+        //        DrawHorizontalLine(y, lineColor);
+        //    }
+        //    else if (y % subdivisionHeight == 0) // 분할선
+        //    {
+        //        lineColor = gridColor;
+        //        DrawHorizontalLine(y, lineColor);
+        //    }
+        //}
+
+        //_gridTexture.Apply();
+
+
+
+        //for (int x = 0; x < column; x++)
+        //{
+        //    int xPos = Mathf.RoundToInt(x * columnWidth);
+
+        //    for (int y = 0; y < _gridTexture.height; y++)
+        //    {
+        //        for (int t = 0; t < lineThickness; t++)
+        //        {
+        //            if (xPos + t < _gridTexture.width)
+        //            {
+        //                _gridTexture.SetPixel(xPos + t, y, gridColor);
+        //            }
+        //        }
+        //    }
+        //}
+
+        //// 가로선 그리기 (박자선)
+        //for (int y = 0; y < _gridTexture.height; y++)
+        //{
+        //    Color lineColor;
+        //    if (y % barHeight == 0) // 마디선
+        //    {
+        //        lineColor = gridColor;
+        //    }
+        //    else if (y % beatHeight == 0) // 박자선
+        //    {
+        //        lineColor = gridColor;
+        //    }
+        //    else if (y % subdivisionHeight == 0) // 분할선
+        //    {
+        //        lineColor = gridColor;
+        //    }
+        //    else
+        //    {
+        //        continue;
+        //    }
+
+        //    for (int x = 0; x < _gridTexture.width; x++)
+        //    {
+        //        for (int t = 0; t < lineThickness; t++)
+        //        {
+        //            if (y + t < _gridTexture.height)
+        //            {
+        //                _gridTexture.SetPixel(x, y + t, lineColor);
+        //            }
+        //        }
+        //    }
+        //}
+
+        //_gridTexture.Apply();
+    }
+
+    private void DrawVerticalLine(int x, Color color)
+    {
+        for (int y = 0; y < _gridTexture.height; y++)
+        {
+            for (int t = 0; t < lineThickness; t++)
+            {
+                if (x + t < _gridTexture.width)
+                {
+                    _gridTexture.SetPixel(x + t, y, color);
+                }
+            }
+        }
+    }
+
+    private void DrawHorizontalLine(int y, Color color)
+    {
+        for (int x = 0; x < _gridTexture.width; x++)
+        {
+            for (int t = 0; t < lineThickness; t++)
+            {
+                if (y + t < _gridTexture.height)
+                {
+                    _gridTexture.SetPixel(x, y + t, color);
+                }
+            }
+        }
+    }
+
+    public void UpdateGridSettings(float newBpm, int newBeatsPerBar, int newSubdivision)
+    {
+        bpm = newBpm;
+        beatsPerBar = newBeatsPerBar;
+        subdivision = newSubdivision;
+        UpdateGrid();
+    }
+
+    public void SetNodesPerBeat(int count)
+    {
+        nodesPerBeat = Mathf.Max(1, count);
+        UpdateGrid();
     }
 }

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,8 +15,8 @@ public class GridManager : MonoBehaviour
     [SerializeField] private float texturePerSecond = 2048f; // 텍스처 해상도 증가
     [Header("Grid 설정")]
     [SerializeField] private float bpm = 120;
-    [SerializeField] private int beatsPerBar = 4; // 마디당 박자의 수
-    [SerializeField] private int subdivision = 4; // 박자
+    //[SerializeField] private int beatsPerBar = 4; // 마디당 박자의 수
+    //[SerializeField] private int subdivision = 4; // 박자
     [SerializeField] private int nodesPerBeat = 1; //비트당 노드 수
     [SerializeField] private int row;    // 열(가로줄)
     [SerializeField] private int column = 4; // 행(세로줄)
@@ -23,6 +24,11 @@ public class GridManager : MonoBehaviour
     [SerializeField] private Color subGridColor = new Color(0.5f, 0.5f, 0.5f, 0.5f); // 서브그리드 색상
     [SerializeField] private Color backgroundColor = Color.white;
     [SerializeField] private float lineThickness = 2f;
+
+    public float BPM => bpm;
+    public int Row => row;
+    public Texture2D GridTexture => _gridTexture;
+    public Action gridInfoCallback;
 
     private AudioSourceManager _audioSourceManager;
     private Texture2D _gridTexture;
@@ -44,6 +50,7 @@ public class GridManager : MonoBehaviour
         if (Application.isPlaying)
         {
             UpdateGrid();
+            gridInfoCallback?.Invoke();
         }
     }
 
@@ -124,101 +131,6 @@ public class GridManager : MonoBehaviour
         }
 
         _gridTexture.Apply();
-        //int subdivisionHeight = Mathf.RoundToInt((_gridTexture.height / (_gridTexture.height / subdivision)) * bpmScale);
-        //int beatHeight = subdivisionHeight * subdivision;
-        //int barHeight = beatHeight * beatsPerBar;
-
-        //노드 서브선
-        //float nodeSubdivisionHeight = beatHeight / (float)nodesPerBeat;
-        //// 세로선 그리기 (열)
-        //float columnWidth = _gridTexture.width / (float)column;
-
-        //for (int x = 0; x < column; x++)
-        //{
-        //    int xPos = Mathf.RoundToInt(x * columnWidth);
-        //    DrawVerticalLine(xPos, gridColor);
-        //}
-
-        //// 가로선 그리기 (박자선, 노드 서브디비전)
-        //for (int y = 0; y < _gridTexture.height; y++)
-        //{
-        //    Color lineColor;
-        //    if (y % barHeight == 0) // 마디선
-        //    {
-        //        lineColor = gridColor;
-        //        DrawHorizontalLine(y, lineColor);
-        //    }
-        //    else if (y % beatHeight == 0) // 박자선
-        //    {
-        //        lineColor = gridColor;
-        //        DrawHorizontalLine(y, lineColor);
-        //    }
-        //    else if (y % nodeSubdivisionHeight < 1) // 노드 서브디비전 선
-        //    {
-        //        lineColor = subGridColor;
-        //        DrawHorizontalLine(y, lineColor);
-        //    }
-        //    else if (y % subdivisionHeight == 0) // 분할선
-        //    {
-        //        lineColor = gridColor;
-        //        DrawHorizontalLine(y, lineColor);
-        //    }
-        //}
-
-        //_gridTexture.Apply();
-
-
-
-        //for (int x = 0; x < column; x++)
-        //{
-        //    int xPos = Mathf.RoundToInt(x * columnWidth);
-
-        //    for (int y = 0; y < _gridTexture.height; y++)
-        //    {
-        //        for (int t = 0; t < lineThickness; t++)
-        //        {
-        //            if (xPos + t < _gridTexture.width)
-        //            {
-        //                _gridTexture.SetPixel(xPos + t, y, gridColor);
-        //            }
-        //        }
-        //    }
-        //}
-
-        //// 가로선 그리기 (박자선)
-        //for (int y = 0; y < _gridTexture.height; y++)
-        //{
-        //    Color lineColor;
-        //    if (y % barHeight == 0) // 마디선
-        //    {
-        //        lineColor = gridColor;
-        //    }
-        //    else if (y % beatHeight == 0) // 박자선
-        //    {
-        //        lineColor = gridColor;
-        //    }
-        //    else if (y % subdivisionHeight == 0) // 분할선
-        //    {
-        //        lineColor = gridColor;
-        //    }
-        //    else
-        //    {
-        //        continue;
-        //    }
-
-        //    for (int x = 0; x < _gridTexture.width; x++)
-        //    {
-        //        for (int t = 0; t < lineThickness; t++)
-        //        {
-        //            if (y + t < _gridTexture.height)
-        //            {
-        //                _gridTexture.SetPixel(x, y + t, lineColor);
-        //            }
-        //        }
-        //    }
-        //}
-
-        //_gridTexture.Apply();
     }
 
     //새로선 그리는 함수
@@ -251,13 +163,13 @@ public class GridManager : MonoBehaviour
         }
     }
 
-    public void UpdateGridSettings(float newBpm, int newBeatsPerBar, int newSubdivision)
-    {
-        bpm = newBpm;
-        beatsPerBar = newBeatsPerBar;
-        subdivision = newSubdivision;
-        UpdateGrid();
-    }
+    //public void UpdateGridSettings(float newBpm, int newBeatsPerBar, int newSubdivision)
+    //{
+    //    bpm = newBpm;
+    //    beatsPerBar = newBeatsPerBar;
+    //    subdivision = newSubdivision;
+    //    UpdateGrid();
+    //}
 
     public void SetNodesPerBeat(int count)
     {

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Managers/GridManager.cs
@@ -113,6 +113,7 @@ public class GridManager : MonoBehaviour
         float columnWidth = _gridTexture.width / (float)column;
         for (int x = 0; x < column; x++)
         {
+            //새로 선 그릴 포지션
             int xPos = Mathf.RoundToInt(x * columnWidth);
             DrawVerticalLine(xPos, gridColor);
         }
@@ -220,6 +221,7 @@ public class GridManager : MonoBehaviour
         //_gridTexture.Apply();
     }
 
+    //새로선 그리는 함수
     private void DrawVerticalLine(int x, Color color)
     {
         for (int y = 0; y < _gridTexture.height; y++)
@@ -234,6 +236,7 @@ public class GridManager : MonoBehaviour
         }
     }
 
+    //가로선 그리는 함수
     private void DrawHorizontalLine(int y, Color color)
     {
         for (int x = 0; x < _gridTexture.width; x++)

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Node.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Node.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Node : MonoBehaviour
+{
+    private int _column;
+    private float _beatTime;
+
+    public int Column => _column;
+    public float BeatTime => _beatTime;
+
+    public void Initialize(int column, float beatTime)
+    {
+        _column = column;
+        _beatTime = beatTime;
+    }
+}

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Node.cs.meta
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/Node.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 475c3adc60d02b94791199793ffb8bfc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/NodeContainer.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/NodeContainer.cs
@@ -1,0 +1,175 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class NodeContainer : MonoBehaviour
+{
+    [SerializeField] private GameObject nodePrefab;
+    [SerializeField] private Transform nodeParent;
+
+    private Camera _editorCamera;
+    private GridManager _gridManager;
+    private AudioSourceManager _audioSourceManager;
+    private Texture2D _texture;
+    private Node[,] _nodeGrid;
+    private int _totalBeats;
+    private GameObject _previewNode;
+    private Color _previewNodeColor = new Color(1, 0, 0, 0.5f);
+    private Material myMaterial;
+    private Material myMaterialPrefab;
+
+    private void Awake()
+    {
+        _gridManager = FindObjectOfType<GridManager>();
+        _editorCamera = FindObjectOfType<Camera>();
+        _audioSourceManager = FindObjectOfType<AudioSourceManager>();
+        //_texture = GetComponent<Renderer>().material.mainTexture as Texture2D;
+    }
+
+    private IEnumerator Start()
+    {
+        yield return new WaitUntil(() => _gridManager.GridTexture != null);
+        InitializeNodeGrid();
+        _gridManager.gridInfoCallback += GridValueChanged;
+    }
+
+    private void Update()
+    {
+        (int column, int beatIndex) = GetGridPositionFromMouse();
+        CreatePreviewNode(column, beatIndex);
+
+        if (Input.GetMouseButtonDown(0))
+        {
+            PlaceNodeMousePosition();
+        }
+    }
+
+    private void GridValueChanged()
+    {
+        InitializeNodeGrid();
+    }
+
+    //노드 이차원 배열 생성
+    private void InitializeNodeGrid()
+    {
+        _texture = _gridManager.GridTexture;
+        float songDuration = _audioSourceManager.AudioDuration;
+
+        //비트당 초
+        float secondsPerBeat = 60f / _gridManager.BPM;
+        //초당 픽셀
+        float pixelsPerSecond = _texture.height / songDuration;
+        //비트당 픽셀
+        float pixelsPerBeat = pixelsPerSecond * secondsPerBeat;
+
+        //셀이 날라가면 안되니 올림
+        _totalBeats = Mathf.CeilToInt(_texture.height / pixelsPerBeat);
+         
+        _nodeGrid = new Node[_gridManager.Row, _totalBeats];
+        print($"그리드 생성 완료 : {_gridManager.Row} x {_totalBeats}");
+    }
+
+    private void PlaceNodeMousePosition()
+    {
+        (int column, int beatIndex) = GetGridPositionFromMouse();
+        print($"행 : {column}, 열 : {beatIndex}");
+        if (column >= 0 && column < 4 && beatIndex >= 0 && beatIndex < _totalBeats)
+        {
+            CreateNode(column, beatIndex);
+        }
+    }
+
+    //여기에서 그리드로 좌표 변환
+    private (int column, int beatIndex) GetGridPositionFromMouse()
+    {
+        Ray ray = _editorCamera.ScreenPointToRay(Input.mousePosition);
+        RaycastHit hit;
+
+        if (Physics.Raycast(ray, out hit) && hit.transform == transform)
+        {
+            Vector3 localHit = transform.InverseTransformPoint(hit.point);
+            print($"로컬좌표 : {localHit}");
+
+            //Plane의 로컬좌표계인 (-5, 5)를 (0, 10)으로 변환하기 위해 5를 더함
+            float normalizedX = (localHit.x + 5f) / 10f * _gridManager.Row;
+            int column = Mathf.Clamp(Mathf.FloorToInt(normalizedX), 0, _gridManager.Row - 1);
+
+            float normalizedZ = (localHit.z + 5f) / 10f * _totalBeats;
+            int beatIndex = Mathf.Clamp(Mathf.FloorToInt(normalizedZ), 0, _totalBeats - 1);
+
+            return (column, beatIndex);
+        }
+        return (-1, -1);
+    }
+
+    //임시 노드
+    private void CreatePreviewNode(int column, int beatIndex) 
+    {
+        if (column < 0 || beatIndex < 0 || column >= _gridManager.Row || beatIndex >= _totalBeats)
+        {
+            if (_previewNode != null)
+            {
+                Destroy(_previewNode);
+                _previewNode = null;
+            }
+            return;
+        }
+
+        if (_nodeGrid[column, beatIndex] != null)
+        {
+            if (_previewNode != null)
+            {
+                Destroy(_previewNode);
+                _previewNode = null;
+            }
+            return;
+        }
+
+        if (_previewNode == null)
+        {
+
+            _previewNode = Instantiate(nodePrefab);
+            Material previewNodeMaterial = _previewNode.GetComponent<MeshRenderer>().material;
+            previewNodeMaterial.color = _previewNodeColor;
+            _previewNode.transform.SetParent(nodeParent, true);
+            _previewNode.transform.localScale = _previewNode.transform.localScale;
+        }
+
+        float cellSizeX = 10f / _gridManager.Row;
+        float cellSizeZ = 10f / _totalBeats;
+
+        float xPos = -5f + (column * cellSizeX) + (cellSizeX / 2f);
+        float zPos = -5f + (beatIndex * cellSizeZ) + (cellSizeZ / 2f);
+
+        _previewNode.transform.position = nodeParent.TransformPoint(new Vector3(xPos, 0.1f, zPos));
+    }
+
+    private void CreateNode(int column, int beatIndex)
+    {
+        if (_nodeGrid[column, beatIndex] != null)
+        {
+            Debug.LogWarning($"이미 노드가 있습니다");
+            return;
+        }
+
+        GameObject nodeObj = Instantiate(nodePrefab);
+        Node node = nodeObj.GetComponent<Node>();
+
+        if (node != null)
+        {
+            float cellSizeX = 10f / _gridManager.Row;
+            float cellSizeZ = 10f / _totalBeats;
+
+            //gridIndex를 실제 위치로 변환(0 ~ 10을 -5 ~ 5로)
+            float xPos = -5f + (column * cellSizeX) + (cellSizeX / 2f);
+            float zPos = -5f + (beatIndex * cellSizeZ) + (cellSizeZ / 2f);
+
+            nodeObj.transform.position = nodeParent.TransformPoint(new Vector3(xPos, 0.1f, zPos));
+            node.transform.SetParent(nodeParent, true);
+
+            node.transform.localScale = nodeObj.transform.localScale;
+            _nodeGrid[column, beatIndex] = node;
+            node.Initialize(column, beatIndex * (60f / _gridManager.BPM));
+        }
+    }
+}

--- a/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/NodeContainer.cs.meta
+++ b/ProjectNT/Assets/03.Code/Scripts/_Editor/LHJ/NodeContainer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e17f678403142247ae2262fdc6b6945
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/Assets/04.Level/Prefabs/Node.prefab
+++ b/ProjectNT/Assets/04.Level/Prefabs/Node.prefab
@@ -61,7 +61,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: e3cb827cbc4e2044f8f2a8d0b5b496da, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/ProjectNT/Assets/04.Level/Prefabs/Node.prefab
+++ b/ProjectNT/Assets/04.Level/Prefabs/Node.prefab
@@ -1,0 +1,110 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &808295560454862083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 808295560454862087}
+  - component: {fileID: 808295560454862080}
+  - component: {fileID: 808295560454862081}
+  - component: {fileID: 808295560454862082}
+  - component: {fileID: 808295560454862086}
+  m_Layer: 0
+  m_Name: Node
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &808295560454862087
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808295560454862083}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3, y: 0.3, z: 0.3}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &808295560454862080
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808295560454862083}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &808295560454862081
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808295560454862083}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &808295560454862082
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808295560454862083}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &808295560454862086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 808295560454862083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 475c3adc60d02b94791199793ffb8bfc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/ProjectNT/Assets/04.Level/Prefabs/Node.prefab.meta
+++ b/ProjectNT/Assets/04.Level/Prefabs/Node.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd7ae4d530c91dd4bab11de8d5565641
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
+++ b/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
@@ -682,7 +682,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10306, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1062,7 +1062,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 10306, guid: 0000000000000000f000000000000000, type: 0}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
+++ b/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
@@ -774,15 +774,13 @@ MonoBehaviour:
   heightScale: 1
   texturePerSecond: 1024
   bpm: 128
-  beatsPerBar: 4
-  subdivision: 4
   nodesPerBeat: 1
   row: 4
   column: 4
   gridColor: {r: 0, g: 0, b: 0, a: 1}
   subGridColor: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   backgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  lineThickness: 1
+  lineThickness: 5
 --- !u!1 &1151394447
 GameObject:
   m_ObjectHideFlags: 0
@@ -1023,6 +1021,7 @@ GameObject:
   - component: {fileID: 1702028897}
   - component: {fileID: 1702028896}
   - component: {fileID: 1702028895}
+  - component: {fileID: 1702028899}
   m_Layer: 0
   m_Name: GridPlane
   m_TagString: Untagged
@@ -1107,6 +1106,21 @@ Transform:
   m_Father: {fileID: 34350517}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1702028899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1702028894}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6e17f678403142247ae2262fdc6b6945, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodePrefab: {fileID: 808295560454862083, guid: bd7ae4d530c91dd4bab11de8d5565641,
+    type: 3}
+  nodeParent: {fileID: 1702028898}
 --- !u!1 &1771951702
 GameObject:
   m_ObjectHideFlags: 0
@@ -1287,6 +1301,75 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &808295560240042195
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 808295560454862083, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_Name
+      value: Node
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 10
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 808295560454862087, guid: bd7ae4d530c91dd4bab11de8d5565641,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bd7ae4d530c91dd4bab11de8d5565641, type: 3}
 --- !u!1001 &2354013932995868719
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
+++ b/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
@@ -772,8 +772,8 @@ MonoBehaviour:
   targetObject: {fileID: 1702028894}
   widthScale: 4
   heightScale: 1
-  texturePerSecond: 10
-  bpm: 120
+  texturePerSecond: 1024
+  bpm: 128
   beatsPerBar: 4
   subdivision: 4
   nodesPerBeat: 1

--- a/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
+++ b/ProjectNT/Assets/04.Level/Scenes/KCY_Scene.unity
@@ -519,7 +519,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 6704232265395456938, guid: dd3a453e427cfe3498b07826f151e292,
     type: 2}
-  m_audioClip: {fileID: 8300000, guid: d81553856c7dc984aab63bbc65d4b350, type: 3}
+  m_audioClip: {fileID: 8300000, guid: fca09404af0a0fb439e93ee8a22bba4f, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -772,12 +772,17 @@ MonoBehaviour:
   targetObject: {fileID: 1702028894}
   widthScale: 4
   heightScale: 1
-  texturePerSecond: 100
+  texturePerSecond: 10
+  bpm: 120
+  beatsPerBar: 4
+  subdivision: 4
+  nodesPerBeat: 1
   row: 4
-  column: 72
+  column: 4
   gridColor: {r: 0, g: 0, b: 0, a: 1}
+  subGridColor: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
   backgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  lineThickness: 0.04
+  lineThickness: 1
 --- !u!1 &1151394447
 GameObject:
   m_ObjectHideFlags: 0
@@ -861,6 +866,101 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1191931945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1191931949}
+  - component: {fileID: 1191931948}
+  - component: {fileID: 1191931947}
+  - component: {fileID: 1191931946}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!65 &1191931946
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191931945}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1191931947
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191931945}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1191931948
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191931945}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1191931949
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191931945}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.8, z: -68.7}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1457933825
 GameObject:
   m_ObjectHideFlags: 0
@@ -923,7 +1023,6 @@ GameObject:
   - component: {fileID: 1702028897}
   - component: {fileID: 1702028896}
   - component: {fileID: 1702028895}
-  - component: {fileID: 1702028899}
   m_Layer: 0
   m_Name: GridPlane
   m_TagString: Untagged
@@ -1008,24 +1107,6 @@ Transform:
   m_Father: {fileID: 34350517}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1702028899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1702028894}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3b6f9c73736ae0b4aa736bc88b00e835, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  row: 12
-  column: 4
-  textureSize: 512
-  gridColor: {r: 0, g: 0, b: 0, a: 1}
-  backgroundColor: {r: 1, g: 1, b: 1, a: 1}
-  lineThickness: 2
 --- !u!1 &1771951702
 GameObject:
   m_ObjectHideFlags: 0

--- a/ProjectNT/Assets/UniversalRenderPipelineAsset.asset
+++ b/ProjectNT/Assets/UniversalRenderPipelineAsset.asset
@@ -1,0 +1,57 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf2edee5c58d82540a51f03df9d42094, type: 3}
+  m_Name: UniversalRenderPipelineAsset
+  m_EditorClassIdentifier: 
+  k_AssetVersion: 5
+  k_AssetPreviousVersion: 5
+  m_RendererType: 1
+  m_RendererData: {fileID: 0}
+  m_RendererDataList:
+  - {fileID: 11400000, guid: 5b1df5605c8ab744ca16107c1a822b51, type: 2}
+  m_DefaultRendererIndex: 0
+  m_RequireDepthTexture: 0
+  m_RequireOpaqueTexture: 0
+  m_OpaqueDownsampling: 1
+  m_SupportsTerrainHoles: 1
+  m_SupportsHDR: 1
+  m_MSAA: 1
+  m_RenderScale: 1
+  m_MainLightRenderingMode: 1
+  m_MainLightShadowsSupported: 1
+  m_MainLightShadowmapResolution: 2048
+  m_AdditionalLightsRenderingMode: 1
+  m_AdditionalLightsPerObjectLimit: 4
+  m_AdditionalLightShadowsSupported: 0
+  m_AdditionalLightsShadowmapResolution: 512
+  m_ShadowDistance: 50
+  m_ShadowCascadeCount: 1
+  m_Cascade2Split: 0.25
+  m_Cascade3Split: {x: 0.1, y: 0.3}
+  m_Cascade4Split: {x: 0.067, y: 0.2, z: 0.467}
+  m_ShadowDepthBias: 1
+  m_ShadowNormalBias: 1
+  m_SoftShadowsSupported: 0
+  m_UseSRPBatcher: 1
+  m_SupportsDynamicBatching: 0
+  m_MixedLightingSupported: 1
+  m_DebugLevel: 0
+  m_UseAdaptivePerformance: 1
+  m_ColorGradingMode: 0
+  m_ColorGradingLutSize: 32
+  m_ShadowType: 1
+  m_LocalShadowsSupported: 0
+  m_LocalShadowsAtlasResolution: 256
+  m_MaxPixelLights: 0
+  m_ShadowAtlasResolution: 256
+  m_ShaderVariantLogLevel: 0
+  m_ShadowCascades: 0

--- a/ProjectNT/Assets/UniversalRenderPipelineAsset.asset.meta
+++ b/ProjectNT/Assets/UniversalRenderPipelineAsset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3582ea2e7595b944be6325de0036629
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/Assets/UniversalRenderPipelineAsset_Renderer.asset
+++ b/ProjectNT/Assets/UniversalRenderPipelineAsset_Renderer.asset
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de640fe3d0db1804a85f9fc8f5cadab6, type: 3}
+  m_Name: UniversalRenderPipelineAsset_Renderer
+  m_EditorClassIdentifier: 
+  m_RendererFeatures: []
+  m_RendererFeatureMap: 
+  postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
+  xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
+  shaders:
+    blitPS: {fileID: 4800000, guid: c17132b1f77d20942aa75f8429c0f8bc, type: 3}
+    copyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
+    screenSpaceShadowPS: {fileID: 4800000, guid: 0f854b35a0cf61a429bd5dcfea30eddd,
+      type: 3}
+    samplingPS: {fileID: 4800000, guid: 04c410c9937594faa893a11dceb85f7e, type: 3}
+    tileDepthInfoPS: {fileID: 0}
+    tileDeferredPS: {fileID: 0}
+    stencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
+    fallbackErrorPS: {fileID: 4800000, guid: e6e9a19c3678ded42a3bc431ebef7dbd, type: 3}
+    materialErrorPS: {fileID: 4800000, guid: 5fd9a8feb75a4b5894c241777f519d4e, type: 3}
+  m_OpaqueLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_TransparentLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_DefaultStencilState:
+    overrideStencilState: 0
+    stencilReference: 0
+    stencilCompareFunction: 8
+    passOperation: 2
+    failOperation: 0
+    zFailOperation: 0
+  m_ShadowTransparentReceive: 1
+  m_RenderingMode: 0
+  m_AccurateGbufferNormals: 0

--- a/ProjectNT/Assets/UniversalRenderPipelineAsset_Renderer.asset.meta
+++ b/ProjectNT/Assets/UniversalRenderPipelineAsset_Renderer.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b1df5605c8ab744ca16107c1a822b51
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectNT/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectNT/ProjectSettings/GraphicsSettings.asset
@@ -43,7 +43,7 @@ GraphicsSettings:
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}
-  m_CustomRenderPipeline: {fileID: 11400000, guid: fc726daddbcf8014193713123dbcd6ff,
+  m_CustomRenderPipeline: {fileID: 11400000, guid: c3582ea2e7595b944be6325de0036629,
     type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}

--- a/ProjectNT/ProjectSettings/QualitySettings.asset
+++ b/ProjectNT/ProjectSettings/QualitySettings.asset
@@ -201,7 +201,7 @@ QualitySettings:
     skinWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 8
+    antiAliasing: 0
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1


### PR DESCRIPTION
## 📝작업 내용

1.  bpm, row, column에 따라 beatMapPlane의 Grid 생성
2. 1bpm 마다 하나의 Node 배치 가능
3. 생성하려는 grid에 Node 미리보기 기능
