### PR TITLE
우퍼 연속 타격시 이전 오디오를 stop하는게 아니라 계속 재생

### DIFF
--- a/ProjectNT/Assets/03.Code/Scripts/Notes/Woofer.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/Notes/Woofer.cs
@@ -26,8 +26,8 @@ public class Woofer : MonoBehaviour
 	{
 		if (_audioSource.isPlaying)
 		{
-			_audioSource.Stop();
-		}
+			// _audioSource.Stop();
+        }
 		if (_audioSource.clip != hitSound)
 			_audioSource.clip = hitSound;
 		


### PR DESCRIPTION
## #️⃣연관된 이슈

- #47 

## 📝작업 내용

> 우퍼 연속 타격시 이전 오디오를 stop하는게 아니라 계속 재생
 