### PR TITLE
[ENV] : 유니티 빌드 Audio - System Sample Rate을 25600으로 변경

### DIFF
--- a/ProjectNT/Assets/03.Code/Scripts/GameManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/GameManager.cs
@@ -14,8 +14,13 @@ public class GameManager : Singleton<GameManager>
 	private void Start()
 	{
 		_noteManager = FindObjectOfType<NoteManager>();
-		// AudioSettings.Reset(default);
-		// GameStart();
+		StartCoroutine(StartCoroutine());
+	}
+	
+	private IEnumerator StartCoroutine()
+	{
+		yield return new WaitForSeconds(5f);
+		GameStart();
 	}
 
 	public void GameStart()

--- a/ProjectNT/Assets/03.Code/Scripts/Notes/AudioManager.cs
+++ b/ProjectNT/Assets/03.Code/Scripts/Notes/AudioManager.cs
@@ -34,10 +34,10 @@ public class AudioManager : Singleton<AudioManager>
 		AudioSource audioSource = _audioPool.GetAudioSource();
 		_audioSources.Add(audioSource);
 		audioSource.clip = clip;
-		double playTime = AudioSettings.dspTime + 0.01; // 현재 시간보다 약간 뒤에 실행
+		double playTime = AudioSettings.dspTime + 0.01;
 		// audioSource.Play();
-		// audioSource.PlayScheduled(playTime);
-		audioSource.PlayOneShot(clip);
+		audioSource.PlayScheduled(playTime);
+		// audioSource.PlayOneShot(clip);
 	}
 	
 	private IEnumerator CheckAudioPlayTime()

--- a/ProjectNT/Assets/04.Level/Scenes/YKD_Prototype.unity
+++ b/ProjectNT/Assets/04.Level/Scenes/YKD_Prototype.unity
@@ -15005,7 +15005,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &380319367
 RectTransform:
   m_ObjectHideFlags: 0
@@ -44547,7 +44547,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   axis: 0
   direction: 0
-  speed: 1
+  speed: 0
 --- !u!1001 &1000321740
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/ProjectNT/ProjectSettings/AudioManager.asset
+++ b/ProjectNT/ProjectSettings/AudioManager.asset
@@ -8,13 +8,13 @@ AudioManager:
   Rolloff Scale: 1
   Doppler Factor: 1
   Default Speaker Mode: 2
-  m_SampleRate: 44100
-  m_DSPBufferSize: 1024
-  m_VirtualVoiceCount: 256
-  m_RealVoiceCount: 64
+  m_SampleRate: 25600
+  m_DSPBufferSize: 256
+  m_VirtualVoiceCount: 128
+  m_RealVoiceCount: 32
   m_EnableOutputSuspension: 1
   m_SpatializerPlugin: 
   m_AmbisonicDecoderPlugin: 
   m_DisableAudio: 0
   m_VirtualizeEffects: 0
-  m_RequestedDSPBufferSize: 1024
+  m_RequestedDSPBufferSize: 256

--- a/ProjectNT/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectNT/ProjectSettings/EditorBuildSettings.asset
@@ -6,8 +6,8 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/04.Level/Scenes/Prototype.unity
-    guid: 9dd46b493c1396a42b3cf2aa11fde485
+    path: Assets/04.Level/Scenes/YKD_Prototype.unity
+    guid: 0c0829bbfc87b3840bce52c1e262a29a
   m_configObjects:
     Unity.XR.Oculus.Settings: {fileID: 11400000, guid: bfa1182bd221b4ca89619141f66f1260,
       type: 2}


### PR DESCRIPTION
## 📝작업 내용

오디오 레이턴시 - 늘어짐을 고치기 위해 BuildSettring - Audio - System Sample Rate : 25600으로 변경